### PR TITLE
Added 5 Non-profits that promote tech in the US

### DIFF
--- a/techquity.md
+++ b/techquity.md
@@ -9,19 +9,29 @@ comments: false
 ---
 ## Tech for Good events, meetups and groups in our community
 
+[__Black Girls Code__](http://www.blackgirlscode.com/) - Black Girls Code (BGC) is a not-for-profit organization that focuses on providing technology education for African-American girls. Kimberly Bryant, an electrical engineer who had worked in biotech for over 20 years, founded Black Girls Code in 2011 to rectify the underrepresentation of female African-Americans in the technology industry.|[__Join__](http://www.blackgirlscode.com/volunteer-signup.html)
+
 [__Civic Data Alliance__](http://civicdataalliance.org) - Louisville's founding Civic Tech org, focused on advocating for inclusion, diversity, equity, accessibility, openness, transparency and accountability in government, civic tech and open data.|[__Meetup__](https://www.meetup.com/Civic-Data-Alliance)
 
 [Code for DC](https://codefordc.org/index.html) - Founded in 2012, we are a a non-partisan, non-political group of volunteer civic hackers working together to solve local issues and help people engage with the city. We host twice-monthly hacknights and other events to gather, discuss, and get stuff done.
 
 [__Data for Democracy__](http://datafordemocracy.org) - Data for Democracy looks for projects that have a strong collaborative nature, and leverage data and technology to create positive social impact.|[__Join__](http://datafordemocracy.org/contact.html)
 
+[__FreeCodeCamp__](http://freecodecamp.org) - freeCodeCamp is a non-profit organization that consists of an interactive learning web platform, an online community forum, chat rooms, Medium publications and local organizations that intend to make learning web development accessible to anyone.|[__Meetups__](https://study-group-directory.freecodecamp.org/)
+
 [__Louisville Sofware Engineers__](https://www.meetup.com/Louisville-Software-Engineering/) - The meetup for all things software engineering in Louisville. A group of language agnostic compassionate code advocates. |[__Meetup__](https://www.meetup.com/Louisville-Software-Engineering/)
+
+[__Girls Who Code__](https://girlswhocode.com/) - Girls Who Code is a nonprofit organization which aims to support and increase the number of women in computer science. The organization is working to close the gender employment difference in technology and change the image of what a programmer looks like. |[__Join__](https://girlswhocode.com/volunteer/)
 
 [__Code Louisville__](https://codelouisville.org/) - A group of language agnostic, compassionate code advocates. Code Louisville produces qualified, dedicated graduates to fill the high demand for talent in the software and tech marketplace throughout the Louisville, Kentucky area. Experienced software developers can contribute to this project as mentors for the students. |[__Learn More__](https://codelouisville.org/mentor)  
 
 [__Louisville Makes Games__](louisvillemakesgames.org/) - The goal of Louisville Makes Games! is to promote game development as a viable career in our city through game development programming classes for children in the area. |[__Meetup__](https://www.meetup.com/LouisvilleMakesGames/)   
 
 [NY JavaScript](https://www.meetup.com/NY-JavaScript/) - We host regular workshops and tech talks on a variety of different JavaScript topics.
+
+[__Operation Code__](https://operationcode.org/) - We're the largest community dedicated to helping military veterans and families launch software development careers.|[__Join__](https://operationcode.org/signup) 
+
+[__#VETSWHOCODE__](https://vetswhocode.io/) - #VetsWhoCode is a veteran-led and operated 501(c)(3) charitable non-profit that focuses on training veterans in web development and software engineering principles free of charge with the focus of starting careers as javascript developers.|[__Join__](https://vetswhocode.io/apply/) 
 
 [__WarpZone__](louisvillemakesgames.org/warpzone/) - Warp Zone Louisville is Kentucky’s first, and only, collaborative workspace focused on game creators! |[__Visit__](louisvillemakesgames.org/warpzone/) 
 


### PR DESCRIPTION
Added non-profits which promote coding for women, veterans, refugees and all sorts of professionals and enthusiasts in the field. For #103 